### PR TITLE
added missing #include <cstring>

### DIFF
--- a/leviosam_utils.hpp
+++ b/leviosam_utils.hpp
@@ -7,6 +7,7 @@
 #include <htslib/sam.h>
 #include <unordered_map>
 #include <vector>
+#include <cstring>
 
 const int8_t seq_comp_table[16] = { 0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15 };
 


### PR DESCRIPTION
Hi Nae-Chyun,
to be able to compile on my system (Ubuntu 20.04), I had to add an extra `#include`. You can merge it into the master if you think it could help also other users.
Ciao!